### PR TITLE
Adding custom domain to NGO support form

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+ngo.seoultechsociety.org


### PR DESCRIPTION
I like  ngo.seoultechsociety.org 
- it's shorter URL
- it's more relevant as this is only for NGO
